### PR TITLE
IN-399 | added: support for custom labels and filters

### DIFF
--- a/kubernetes/tests/metric_test.yaml
+++ b/kubernetes/tests/metric_test.yaml
@@ -140,5 +140,9 @@ spec:
         - pod_name: promtail
     loki:
       dimensions:
-        - namespace: nyala
-          grofers.io/service: nyala
+        - labels:
+            namespace: sample-namespace
+        - labels:
+            namespace: sample-namespace-2
+          filters:
+            - "err"

--- a/legend/metrics_library/metrics/loki_metrics.yaml
+++ b/legend/metrics_library/metrics/loki_metrics.yaml
@@ -10,7 +10,15 @@ panels:
       description: Logs with respect to the provided service key (default no such filter)
       targets:
         {% for dimension in data %}
-          - expr: '{namespace=~"{{ dimension.get("namespace") }}", grofers_io_service=~"{{ dimension.get("grofers.io/service") }}", grofers_io_component=~"{{ dimension.get("grofers.io/component") }}", grofers_io_component_role=~"{{ dimension.get("grofers.io/component-role") }}", grofers_io_business_service=~"{{ dimension.get("grofers.io/business-service") }}", grofers_io_team=~"{{ dimension.get("grofers.io/team") }}", grofers_io_tribe=~"{{ dimension.get("grofers.io/tribe") }}", grofers_io_owner=~"{{ dimension.get("grofers.io/owner") }}"}'
+          {% set filter_dict = {'filters': 'namespace=~"'+ dimension.get("labels").get("namespace")+ '"' } %}    #### after being filled up, it would look like, filter_dict = {"filters": "namespace=~xyz, label1=value1, label2=value2" }
+          {% for label in dimension.get("labels").keys() %}
+            {% if label!="namespace" and filter_dict.update({
+                "filters": filter_dict.filters + ', ' + label.replace("/", "_").replace(".", "_").replace("-", "_") + "=~" + '"' + dimension.get("labels").get(label) + '"'
+              }) %} 
+              {% endif %}
+          {% endfor %}
+          {% set expression = filter_dict.get('filters') %}
+          - expr: '{ {{ expression }} }'
         {% endfor %}
     - title: Error Logs
       type: Log
@@ -18,20 +26,39 @@ panels:
       description: All the logs associated with any error
       targets:
         {% for dimension in data %}
-          - expr: '{namespace=~"{{ dimension.get("namespace") }}", grofers_io_service=~"{{ dimension.get("grofers.io/service") }}", grofers_io_component=~"{{ dimension.get("grofers.io/component") }}", grofers_io_component_role=~"{{ dimension.get("grofers.io/component-role") }}", grofers_io_business_service=~"{{ dimension.get("grofers.io/business-service") }}", grofers_io_team=~"{{ dimension.get("grofers.io/team") }}", grofers_io_tribe=~"{{ dimension.get("grofers.io/tribe") }}", grofers_io_owner=~"{{ dimension.get("grofers.io/owner") }}"} |~ "err"' ##  {namespace="nyala"} |~ "err"
+          {% set filter_dict = {'filters': 'namespace=~"'+ dimension.get("labels").get("namespace")+ '"' } %}    #### after being filled up, it would look like, filter_dict = {"filters": "namespace=~xyz, label1=value1, label2=value2" }
+          {% for label in dimension.get("labels").keys() %}
+            {% if label!="namespace" and filter_dict.update({
+                "filters": filter_dict.filters + ', ' + label.replace("/", "_").replace(".", "_").replace("-", "_") + "=~" + '"' + dimension.get("labels").get(label) + '"'
+              }) %} 
+              {% endif %}
+          {% endfor %}
+          {% set expression = filter_dict.get('filters') %}
+          - expr: '{ {{ expression }} } |~ "(?i)err"' ##  {namespace="nyala", customlabel1=value1, customlabel2=value2, ....} |~ "(?i)err"
         {% endfor %}
-    - title: 4xx-status error logs
+    {% for dimension in data%}
+      {% if "filters" in dimension.keys() %}
+        {% set custom_labels_dict = {'custom_labels': 'namespace=~"'+ dimension.get("labels").get("namespace")+ '"' } %}  
+        {% for label in dimension.get("labels").keys() %}
+          {% if label!="namespace" and custom_labels_dict.update({
+              "custom_labels": custom_labels_dict.custom_labels + ', ' + label.replace("/", "_").replace(".", "_").replace("-", "_") + "=~" + '"' + dimension.get("labels").get(label) + '"'
+            }) %} 
+            {% endif %}
+        {% endfor %}
+        {% set custom_filters_dict = {'custom_filters': '' } %}
+        {% for filter in dimension.get("filters") %}
+          {% if custom_filters_dict.update({
+            "custom_filters": custom_filters_dict.custom_filters + ' |~ "' + filter + '"'
+          }) %} 
+          {% endif %}
+        {% endfor %}
+        {% set finalExpression = "{ " + custom_labels_dict.get('custom_labels') + " }" +  custom_filters_dict.get("custom_filters") %}
+    - title: Custom Log Panel - {{ finalExpression }}
       type: Log
-      sort_order: descending
+      sort_order: Descending
+      description: Custom Log Panel for the query - {{ finalExpression }}
       targets:
-        {% for dimension in data %}
-          - expr: '{namespace=~"{{ dimension.get("namespace") }}", grofers_io_service=~"{{ dimension.get("grofers.io/service") }}", grofers_io_component=~"{{ dimension.get("grofers.io/component") }}", grofers_io_component_role=~"{{ dimension.get("grofers.io/component-role") }}", grofers_io_business_service=~"{{ dimension.get("grofers.io/business-service") }}", grofers_io_team=~"{{ dimension.get("grofers.io/team") }}", grofers_io_tribe=~"{{ dimension.get("grofers.io/tribe") }}", grofers_io_owner=~"{{ dimension.get("grofers.io/owner") }}"} |~ "[^0-9]4[0-9]{2}[^0-9]" |~ "GET|POST|PUT|DELETE|PATCH"' ##  {namespace="nyala"} |~ "HTTP GET /route 404 1.1"
-        {% endfor %}
-    - title: 5xx-status error logs
-      type: Log
-      sort_order: descending
-      targets:
-        {% for dimension in data %}
-          - expr: '{namespace=~"{{ dimension.get("namespace") }}", grofers_io_service=~"{{ dimension.get("grofers.io/service") }}", grofers_io_component=~"{{ dimension.get("grofers.io/component") }}", grofers_io_component_role=~"{{ dimension.get("grofers.io/component-role") }}", grofers_io_business_service=~"{{ dimension.get("grofers.io/business-service") }}", grofers_io_team=~"{{ dimension.get("grofers.io/team") }}", grofers_io_tribe=~"{{ dimension.get("grofers.io/tribe") }}", grofers_io_owner=~"{{ dimension.get("grofers.io/owner") }}"} |~ "[^0-9]5[0-9]{2}[^0-9]"  |~ "GET|POST|PUT|DELETE|PATCH"' ##  {namespace="nyala"} |~ "HTTP GET /route 500 1.1"
-        {% endfor %}
+      - expr: '{{ finalExpression }}'
+    {% endif %}
+    {% endfor %}
 

--- a/legend/metrics_library/metrics_schema.py
+++ b/legend/metrics_library/metrics_schema.py
@@ -362,15 +362,18 @@ loki_schema = {
         "schema": {
             "type": "dict",
             "schema": {
-                "namespace": {"type": "string", "required": True},
-                "grofers.io/service": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/component": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/component-role": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/business-service": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/team": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/owner": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-                "grofers.io/tribe": {"type": "string", "required": False, "default": "[a-zA-Z]*"},
-            }
-        }
+                "labels": {
+                    "type": "dict", 
+                    "required": True,
+                    "schema": {
+                        "namespace": {"type": "string", "required": True,}
+                    }
+                },
+                "filters": {
+                    "type": "list", 
+                    "required": False,
+                },
+            },
+        },
     }
 }

--- a/sample_input.yaml
+++ b/sample_input.yaml
@@ -134,5 +134,9 @@ components:
       - pod_name: promtail
   loki:
     dimensions:
-      - namespace: sample-ns
-        service: sample-service
+      - labels:
+          namespace: sample-namespace
+      - labels:
+          namespace: sample-namespace-2
+        filters:
+          - "err"


### PR DESCRIPTION
now, custom labels and filters can be provided for building loki-based log panels.
- For all the dimensions, there will be 1 Log Panel built for "all" logs of all dimensions
- For all the dimensions, there will be 1 Log Panel built for "err" type logs associated with all dimensions.
- For each dimensions having "filters" field under it, there will be a Log Panel built for the corresponding expression built out of its "labels" and "filters". 

So, for the below manifest, a dashboard with the following panels will be generated: ( [Link to the sample dashboard]( https://grafana-stage.grofer.io/d/heVooUOMz/loki-metrics-prod)  )
- **All Logs** :  It will contain all the logs of all the dimensions (2 in the below example)
- **Error Logs** :  It will contain all the error-type logs associated with all the dimensions.
- **Custom Log Panel -  {namespace=~ "nyala", grofers_io_service=~ "nyala"} |~ "HTTP GET /route 404 1.1" |~ "err"** : Custom Log Panel corresponding to the first dimension object built out of the `labels` and `filters` provided in it.
- **Custom Log Panel -  {namespace=~ "monitoring"} |~ "err"** : Custom Log Panel corresponding to the second dimension object built out of the `labels` and `filters` provided in it.
```
      loki:
        dimensions:
          - labels:
              namespace: nyala
              grofers.io/service: nyala
            filters: 
              - "HTTP GET /route 404 1.1"
              - "err"
          - labels:
              namespace: monitoring
            filters:
              - "err"
```