### PR TITLE
IN-505 | feat: added support for nginx metric-based dashboard creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Say you got an EC2 to monitor, an S3 to monitor, a Kubernetes cronjob to monitor
   * Loki
   * MySQL - RDS
   * MySQL - EC2
+  * NGINX (Log-based metrics)
   * NodeJS
   * PostgreSQL
   * PgBouncer
@@ -60,7 +61,7 @@ Say you got an EC2 to monitor, an S3 to monitor, a Kubernetes cronjob to monitor
   * SQS
   * Starlette
   * Hashicorp Vault
-* Legend currently has the capability to further have support for any other component, provided that component's log generation is backed by one of the following exporters:
+* Legend currently has the capability to further have support for any other component, provided that component's log generation is backed by one of the following metric/log stores:
   * Cloudwatch
   * InfluxDB
   * Loki

--- a/docs/enabling-monitoring.md
+++ b/docs/enabling-monitoring.md
@@ -14,7 +14,7 @@
 * [Nodejs](#nodejs)
 * [Golang](#golang)
 * [PgBouncer](#PgBouncer)
-
+* [Nginx](#Nginx)
 ## Django
 
 ### Configure prometheus metrics exporter
@@ -293,3 +293,10 @@ Install from: [https://github.com/prometheus/client_golang](https://github.com/p
 # PgBouncer
 
 Please setup PgBouncer exporter from [here](https://github.com/spreaker/prometheus-pgbouncer-exporter).
+
+# NGINX
+
+* Please setup the Prometheus-NginxLog-Exporter from [here](https://github.com/martin-helmich/prometheus-nginxlog-exporter).
+* Please setup namespacing over your NGINX (don't mistake this for kubernetes namespace. They are not at all related ). Refer to [this](https://github.com/martin-helmich/prometheus-nginxlog-exporter#namespace-as-labels) for more details around nginx namespacing. 
+  * Do not use any other special characters apart from "underscores" (_) while naming any namespace as the namespace names are used directly as placeholders in the names of the metrics created by the above exporter (for example `<namespace>_http_response_count_total`) and prometheus would expect all the metric names to NOT contain any special character apart from underscores (\_).
+* Finally, setup a Prometheus server to periodically scrape the `/metrics` endpoint exposed by the above prometheus-nginxlog-exporter thereby, exposing the required NGINX metrics. 

--- a/kubernetes/tests/metric_test.yaml
+++ b/kubernetes/tests/metric_test.yaml
@@ -117,6 +117,9 @@ spec:
         dimensions:
           - bucket_name: sample-s3-bucket
             filter_id: EntireBucket
+      nginx:
+        dimensions:
+          - nginx_namespace: sample_nginx_namespace
 
     # Data science tools
       airflow:

--- a/legend/metrics_library/metrics/nginx_metrics.j2
+++ b/legend/metrics_library/metrics/nginx_metrics.j2
@@ -1,0 +1,101 @@
+component: nginx
+data_source_type: Prometheus
+metrics_source: https://github.com/martin-helmich/prometheus-nginxlog-exporter
+reference: https://blog.ruanbekker.com/blog/2020/04/25/nginx-metrics-on-prometheus-with-the-nginx-log-exporter
+description: Prometheus-nginxlog-exporter constructs a bunch of metrics on the basis of the contents of the nginx access log file. All the metrics are prepended by "<nginx namespace>_". For example, for the provided nginx namespace "myns", myns_http_response_count_total metric will give the total count of HTTP requests processed for the "myns" namespace.
+panels:
+  - title: (R) Average response time latency
+    type: Graph
+    description: Average response time latency of all the http requests over the last 5 minutes.
+    formatY1: s
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate(sum({{dimension.nginx_namespace}}_http_response_time_seconds[5m]))) by (instance) / sum(rate(count({{dimension.nginx_namespace}}_http_response_time_seconds[5m]))) by (instance)
+        legend: 'Namespace: {{'{{namespace}}'}} Instance: {{'{{instance}}'}}'
+    {% endfor %}
+
+  - title: (R) Rate of requests
+    type: Graph
+    description: Per-second rate of incoming requests as per last 1 minute.
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate(count({{dimension.nginx_namespace}}_http_response_time_seconds[1m]))) by (instance)
+        legend: 'Namespace: {{'{{namespace}}'}} Instance: {{'{{instance}}'}}'
+    {% endfor %}
+
+  - title: (D) GET Response time latency (95th percentile)
+    type: Graph
+    description: p95 Response time latency of all the 2xx GET responses
+    formatY1: s
+    targets:
+    {% for dimension in data %}
+      - metric: {{dimension.nginx_namespace}}_http_response_time_seconds{quantile="0.95",method="GET",status=~"2[0-9]*"}
+        legend: 'Namespace: {{'{{namespace}}'}} Status: All 2xx'
+        statistic: p95
+        ref_no: 1
+      - metric: sum({{dimension.nginx_namespace}}_http_response_time_seconds{quantile="0.95",method="GET",status=~"2[0-9]*"}) by (status)
+        legend: 'Namespace: {{'{{namespace}}'}} Status: {{status}}'
+        statistic: p95
+    {% endfor %}
+    alert_config:
+      priority: P3
+      message: 'Spike in p95 GET Response time latency'
+      rule:
+        for_duration: 5m
+        evaluate_every: 1m
+      condition_query:
+      - OR,avg,1,now,5m,gt,0.15
+
+  - title: (R) HTTP Traffic Content
+    type: Graph
+    description: Per-second rate of content transferred (bytes) over the last 5 minutes.
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate({{dimension.nginx_namespace}}_http_response_size_bytes[5m])) by (instance)
+        legend: 'Namespace: {{'{{namespace}}'}} Instance: {{'{{instance}}'}}'
+    {% endfor %}
+
+  - title: (R) Rate of successful responses (2xx)
+    type: Graph
+    description: Per-second rate of successful (2xx) responses segregated by status codes over the last 1 minute.  
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate({{dimension.nginx_namespace}}_http_response_count_total{status=~"2[0-9]*"}[1m])) by (status)
+        legend: 'Namespace: {{'{{namespace}}'}} Status: {{status}}'
+    {% endfor %}
+
+  - title: (E) Server-side error rate (5xx)
+    type: Graph
+    description: Per-second rate of unsuccessful server-side error responses (5xx) segregated by status codes over the last 1 minute.  
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate({{dimension.nginx_namespace}}_http_response_count_total{status=~"5[0-9]*"}[1m])) by (status)
+        legend: 'Namespace: {{'{{namespace}}'}} Status: {{status}}'
+    {% endfor %}
+        ref_no: 1
+    alert_config:
+      priority: P3
+      message: 'Spike in server-side error rate (5xx)'
+      rule:
+        for_duration: 5m
+        evaluate_every: 1m
+      condition_query:
+      - OR,avg,1,now,5m,gt,30
+
+  - title: (E) Client-side error rate (4xx)
+    type: Graph
+    description: Per-second rate of unsuccessful client-side error responses (4xx) segregated by status codes over the last 1 minute.  
+    targets:
+    {% for dimension in data %}
+      - metric: sum(rate({{dimension.nginx_namespace}}_http_response_count_total{status=~"4[0-9]*"}[1m])) by (status)
+        legend: 'Namespace: {{'{{namespace}}'}} Status: {{status}}'
+        ref_no: 1
+    {% endfor %}
+    alert_config:
+      priority: P4
+      message: 'Spike in client-side error rate (4xx)'
+      rule:
+        for_duration: 5m
+        evaluate_every: 1m
+      condition_query:
+      - OR,avg,1,now,5m,gt,75

--- a/legend/metrics_library/metrics_schema.py
+++ b/legend/metrics_library/metrics_schema.py
@@ -485,3 +485,16 @@ loki_schema = {
         },
     },
 }
+
+nginx_schema = {
+    "data_source": {"type": "string", "required": False},
+    "dimensions": {
+        "type": "list",
+        "schema": {
+            "type": "dict",
+            "schema": {
+                "nginx_namespace": {"type": "string", "required": True},
+            },
+        },
+    },
+}

--- a/legend/metrics_library/schema.py
+++ b/legend/metrics_library/schema.py
@@ -32,6 +32,7 @@ from .metrics_schema import (
     platform_k8s_cronjob_schema,
     platform_k8s_hpa_schema,
     loki_schema,
+    nginx_schema,
 )
 
 
@@ -330,6 +331,11 @@ schema = {
             "loki": {
                 "type": "dict",
                 "schema": md(default_panels_schema, loki_schema),
+                "required": False,
+            },
+            "nginx": {
+                "type": "dict",
+                "schema": md(default_panels_schema, nginx_schema),
                 "required": False,
             },
         },

--- a/sample_input.yaml
+++ b/sample_input.yaml
@@ -123,6 +123,9 @@ components:
     dimensions:
       - bucket_name: sample-s3-bucket
         filter_id: EntireBucket
+  nginx:
+    dimensions:
+      - nginx_namespace: sample_nginx_namespace
 
 # Data science tools
   airflow:


### PR DESCRIPTION
Adds the capability to legend to spin up NGINX metrics based dashboards provided the user already has a prometheus data source consisting of NGINX metrics exported in the first place by [Prometheus-NginxLog-Exporter](https://github.com/martin-helmich/prometheus-nginxlog-exporter).