### PR TITLE
KUB-40 - Fixing expression for AWS ELB

### DIFF
--- a/legend/metrics_library/metrics/elb_metrics.j2
+++ b/legend/metrics_library/metrics/elb_metrics.j2
@@ -40,6 +40,7 @@ panels:
         metric: SurgeQueueLength
         namespace: AWS/ELB
         statistic: Maximum
+        expression: "FILL(SEARCH('{AWS/ELB,LoadBalancerName} MetricName=SurgeQueueLength LoadBalancerName=({{ dimension.load_balancer_name }})', 'Sum', 60), 0)"
         alias: '{{ '{{LoadBalancerName}}_{{metric}}_{{stat}}' }}'
         ref_no: 1
       {% endfor %}


### PR DESCRIPTION
There were false alerts generated in case there were no pending requests. AWS cloudwatch does not provide metric to 0 in case there are no pending requests so this will fix it.

## What we are doing here:-
- We are changing to expression to fill 0 values in case there are metrics missing[no pending requests].
