### PR TITLE
KUB-65 - Fixing update_handler function

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -26,7 +26,7 @@ jobs:
           config: charts/legend/
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 

--- a/charts/legend/Chart.yaml
+++ b/charts/legend/Chart.yaml
@@ -4,7 +4,7 @@ description: Grafana Dashboard Generator
 home: https://github.com/grofers/legend
 
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.1.0
 kubeVersion: ">=1.16.0-0"
 

--- a/charts/legend/crds/grafana-dashboards.yaml
+++ b/charts/legend/crds/grafana-dashboards.yaml
@@ -31,10 +31,10 @@ spec:
       - name: Dashboard URL
         type: string
         priority: 0
-        jsonPath: .status.create_handler.grafana_url
+        jsonPath: .status.handler.grafana_url
         description: URL for the Grafana dashboard.
       - name: Status
         type: string
         priority: 0
-        jsonPath: .status.create_handler.status
+        jsonPath: .status.handler.status
         description: Status of the Grafana dashboard.

--- a/kubernetes/handler.py
+++ b/kubernetes/handler.py
@@ -67,7 +67,7 @@ def create_or_update_handler(spec, name, **kwargs):
 
 
 @kopf.on.create("grofers.io", "v1beta1", "grafana-dashboards")
-def create_handler(spec, name, **kwargs):
+def handler(spec, name, **kwargs):
     logger.info("Creating new Grafana dashboard: %s", name)
     kopf.info(
         spec, reason="CreatingDashboard", message="Creating new grafana-dashboard."
@@ -101,19 +101,20 @@ def create_handler(spec, name, **kwargs):
 
 @kopf.on.resume("grofers.io", "v1beta1", "grafana-dashboards")
 @kopf.on.update("grofers.io", "v1beta1", "grafana-dashboards")
-def update_handler(spec, name, **kwargs):
+def handler(spec, name, **kwargs):
     logger.info("Updating existing Grafana dashboard object: %s", name)
     kopf.info(spec, reason="UpdatingDashboard", message="Updating Grafana dashboard.")
     logger.debug("Got the following keyword args for udpating the object: %s", kwargs)
 
     try:
-        create_or_update_handler(spec, name, **kwargs)
+        resp = create_or_update_handler(spec, name, **kwargs)
         kopf.info(
             spec,
             reason="UpdatedDashboard",
             message="Finished updating Grafana dashboard: %s." % name,
         )
         logger.info("Finished updating Grafana dashboard: %s", name)
+        return resp
     except Exception as e:
         logger.error(
             (
@@ -140,8 +141,8 @@ def delete_handler(spec, name, body, **kwargs):
     # was successful earlier
     if "status" in body:
         status = body["status"]
-        if status.get("create_handler") or status.get("update_handler"):
-            uid = body["status"]["create_handler"]["uid"]
+        if status.get("handler"):
+            uid = body["status"]["handler"]["uid"]
 
             try:
                 legend_config = load_legend_config()

--- a/kubernetes/handler.py
+++ b/kubernetes/handler.py
@@ -71,29 +71,34 @@ def create_or_update_handler(spec, name, **kwargs):
 def handler(spec, name, **kwargs):
     logger.debug("Event: %s",kwargs['event'])
     action=kwargs["event"]
-    if action == 'create':
-        logger.info("Creating new Grafana dashboard: %s", name)
-        kopf.info(
-            spec, reason="CreatingDashboard", message="Creating new grafana-dashboard."
-        )
-        logger.debug("Got the following keyword args for creating the object: %s", kwargs)
-    else:
-        logger.info("Updating existing Grafana dashboard object: %s", name)
-        kopf.info(spec, reason="UpdatingDashboard", message="Updating Grafana dashboard.")
-        logger.debug("Got the following keyword args for updating the object: %s", kwargs)
-    
     try:
-        resp = create_or_update_handler(spec, name, **kwargs)
         if action == 'create':
+            logger.info("Creating new Grafana dashboard: %s", name)
+            kopf.info(
+                spec, reason="CreatingDashboard", message="Creating new grafana-dashboard."
+            )
+            logger.debug("Got the following keyword args for creating the object: %s", kwargs)
+
+            resp = create_or_update_handler(spec, name, **kwargs)
+
             kopf.info(
                 spec,reason="CreatedDashboard",message=("Finished creating dashboard " "at %s." % resp["grafana_url"])
             )
             logger.info("Finished creating Grafana dashboard: %s", name)            
         else:
+            logger.info("Updating existing Grafana dashboard object: %s", name)
+            kopf.info(
+                spec, reason="UpdatingDashboard", message="Updating Grafana dashboard."
+            )
+            logger.debug("Got the following keyword args for updating the object: %s", kwargs) 
+
+            resp = create_or_update_handler(spec, name, **kwargs)
+
             kopf.info(
                 spec,reason="UpdatedDashboard",message="Finished updating Grafana dashboard: %s." % name
             )
             logger.info("Finished updating Grafana dashboard: %s", name)
+            
         return resp
         
     except Exception as e:


### PR DESCRIPTION
- Renamed handler functions from `create_handler` and `update_handler` to `handler`.
- Referencing `handler` function in CRD for fetching status and URL

***Why?***
To handle the edge case where if the dashboard is deleted manually from grafana, then on applying the manifest again the new dashboard URL should be visible in GrafanaDashboard CRD status. 
Earlier the new dashboard would get generated but the CRD would be showing on the initial URL. 