### PR TITLE
adding MarkupSafe version 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ jsonnet==0.17.0
 cerberus==1.3.2
 sentry-sdk==0.19.5
 black==19.10b0
+MarkupSafe==2.0.1


### PR DESCRIPTION
There is an upgrade in MarkupSafe:2.1.0 where they have removed soft_unicode.
Release note: https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

In the jinja2 library, it mentioned using MarkupSafe>=2.0.
https://github.com/pallets/jinja/blob/1c4066a4fad5aaeb2ac55809d1d38477cd23a0f6/setup.py#L6
