### PR TITLE
Update platform_k8s_hpa_metrics.j2

### DIFF
--- a/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
+++ b/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
@@ -9,7 +9,7 @@ panels:
     description: Check if Total Number of Pods less than Min Pods
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment=~"^{{ dimension.deployment_name }}.*"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment="{{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}
@@ -27,7 +27,7 @@ panels:
     description: Check if Total Number of Pods equal to Max Pods for long
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment=~"^{{ dimension.deployment_name }}.*"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment="{{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}


### PR DESCRIPTION
Make the numerator exact match (same as the denominator)

Either this or we should support something like (to show all the metrics in a single graph):
> [Grafana](https://grafana.grofers.com/d/1LIco9Ynz/track-order-service-usered?orgId=1&from=now-1h&to=now&editPanel=32)
```
kube_deployment_status_replicas_available{deployment=~"^track-order.*"} / on (deployment) label_replace(kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler=~"^track-order.*"}, "deployment", "$1", "horizontalpodautoscaler", "(.*)")
```
but this assumes that hpa_name == deployment_name which might not always be true