### PR TITLE
fixing the deployment pod name regex

### DIFF
--- a/legend/metrics_library/metrics/platform_k8s_deployment_metrics.j2
+++ b/legend/metrics_library/metrics/platform_k8s_deployment_metrics.j2
@@ -9,7 +9,7 @@ panels:
     description: current cpu utilisation per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}.*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -28,7 +28,7 @@ panels:
     description: Amount of time the container was throttled
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_cpu_cfs_throttled_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (container)
+      - metric: sum(rate(container_cpu_cfs_throttled_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container)
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: s
@@ -38,7 +38,7 @@ panels:
     description: Current memory usage per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}.*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}.*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -57,7 +57,7 @@ panels:
     description: Amount of available memory from the limit
     targets:
       {% for dimension in data %}
-      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}.*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}.*", resource="memory", unit="byte"}) by (container))
+      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container))
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: bytes
@@ -67,9 +67,9 @@ panels:
     description: bytes read/written
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_fs_writes_bytes_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (container,device)
+      - metric: sum(rate(container_fs_writes_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container,device)
         legend: '{{ '{{container}} {{device}} Writes' }}'
-      - metric: sum(rate(container_fs_reads_bytes_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (container,device)
+      - metric: sum(rate(container_fs_reads_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container,device)
         legend: '{{ '{{container}} {{device}} Reads' }}'
       {% endfor %}
     formatY1: bytes
@@ -79,9 +79,9 @@ panels:
     description: bytes received/transmitted
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_network_receive_bytes_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (pod, interface)
+      - metric: sum(rate(container_network_receive_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod, interface)
         legend: '{{ '{{pod}} rx' }}'
-      - metric: sum(rate(container_network_transmit_bytes_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (pod, interface)
+      - metric: sum(rate(container_network_transmit_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod, interface)
         legend: '{{ '{{pod}} tx' }}'
       {% endfor %}
 
@@ -90,9 +90,9 @@ panels:
     description: Number of network errors
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_network_receive_errors_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (pod)
+      - metric: sum(rate(container_network_receive_errors_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod)
         legend: '{{ '{{pod}} rx' }}'
-      - metric: sum(rate(container_network_transmit_errors_total{pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (pod)
+      - metric: sum(rate(container_network_transmit_errors_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod)
         legend: '{{ '{{pod}} tx' }}'
       {% endfor %}
 
@@ -130,7 +130,7 @@ panels:
     description: current cpu utilisation per container from the request
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}.*"}[5m])) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}.*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -141,7 +141,7 @@ panels:
     description: Amount of available memory from the request
     targets:
       {% for dimension in data %}
-      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}.*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}.*", resource="memory", unit="byte"}) by (container))
+      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container))
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: bytes
@@ -151,7 +151,7 @@ panels:
     description: Current memory usage per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}.*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}.*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}

--- a/legend/metrics_library/metrics/platform_k8s_deployment_metrics.j2
+++ b/legend/metrics_library/metrics/platform_k8s_deployment_metrics.j2
@@ -9,7 +9,7 @@ panels:
     description: current cpu utilisation per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -28,7 +28,7 @@ panels:
     description: Amount of time the container was throttled
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_cpu_cfs_throttled_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container)
+      - metric: sum(rate(container_cpu_cfs_throttled_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (container)
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: s
@@ -38,7 +38,7 @@ panels:
     description: Current memory usage per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -57,7 +57,7 @@ panels:
     description: Amount of available memory from the limit
     targets:
       {% for dimension in data %}
-      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container))
+      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}) by (container) / sum(kube_pod_container_resource_limits{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="memory", unit="byte"}) by (container))
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: bytes
@@ -67,9 +67,9 @@ panels:
     description: bytes read/written
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_fs_writes_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container,device)
+      - metric: sum(rate(container_fs_writes_bytes_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (container,device)
         legend: '{{ '{{container}} {{device}} Writes' }}'
-      - metric: sum(rate(container_fs_reads_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container,device)
+      - metric: sum(rate(container_fs_reads_bytes_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (container,device)
         legend: '{{ '{{container}} {{device}} Reads' }}'
       {% endfor %}
     formatY1: bytes
@@ -79,9 +79,9 @@ panels:
     description: bytes received/transmitted
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_network_receive_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod, interface)
+      - metric: sum(rate(container_network_receive_bytes_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (pod, interface)
         legend: '{{ '{{pod}} rx' }}'
-      - metric: sum(rate(container_network_transmit_bytes_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod, interface)
+      - metric: sum(rate(container_network_transmit_bytes_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (pod, interface)
         legend: '{{ '{{pod}} tx' }}'
       {% endfor %}
 
@@ -90,9 +90,9 @@ panels:
     description: Number of network errors
     targets:
       {% for dimension in data %}
-      - metric: sum(rate(container_network_receive_errors_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod)
+      - metric: sum(rate(container_network_receive_errors_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (pod)
         legend: '{{ '{{pod}} rx' }}'
-      - metric: sum(rate(container_network_transmit_errors_total{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (pod)
+      - metric: sum(rate(container_network_transmit_errors_total{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (pod)
         legend: '{{ '{{pod}} tx' }}'
       {% endfor %}
 
@@ -130,7 +130,7 @@ panels:
     description: current cpu utilisation per container from the request
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}[5m])) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(rate(container_cpu_usage_seconds_total{container!~"POD", pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}[5m])) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="cpu", unit="core"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}
@@ -141,7 +141,7 @@ panels:
     description: Amount of available memory from the request
     targets:
       {% for dimension in data %}
-      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container))
+      - metric: (sum(container_memory_working_set_bytes{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="memory", unit="byte"}) by (container))
         legend: '{{ '{{container}}' }}'
       {% endfor %}
     formatY1: bytes
@@ -151,7 +151,7 @@ panels:
     description: Current memory usage per container
     targets:
       {% for dimension in data %}
-      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
+      - metric: round(((sum(container_memory_working_set_bytes{container!~"POD", pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+"}) by (container) / sum(kube_pod_container_resource_requests{pod=~"^{{ dimension.deployment_name }}-\\w+-\\w+", resource="memory", unit="byte"}) by (container)) * 100), 0.1)
         legend: '{{ '{{container}}' }}'
         ref_no: 1
       {% endfor %}

--- a/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
+++ b/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
@@ -9,7 +9,7 @@ panels:
     description: Check if Total Number of Pods less than Min Pods
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment=~"^{{ dimension.deployment_name }}.*"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment={{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}
@@ -27,7 +27,7 @@ panels:
     description: Check if Total Number of Pods equal to Max Pods for long
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment=~"^{{ dimension.deployment_name }}.*"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment={{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}

--- a/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
+++ b/legend/metrics_library/metrics/platform_k8s_hpa_metrics.j2
@@ -9,7 +9,7 @@ panels:
     description: Check if Total Number of Pods less than Min Pods
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment={{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment="{{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}
@@ -27,7 +27,7 @@ panels:
     description: Check if Total Number of Pods equal to Max Pods for long
     targets:
       {% for dimension in data %}
-      - metric: kube_deployment_status_replicas_available{deployment={{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
+      - metric: kube_deployment_status_replicas_available{deployment="{{ dimension.deployment_name }}"} / on (service) group_left(horizontalpodautoscaler) kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="{{ dimension.hpa_name }}"}
         legend: '{{ ' {{deployment}} ' }}'
         ref_no: 1
       {% endfor %}


### PR DESCRIPTION
The expression `pod=~"^{{ dimension.deployment_name }}.*"` for fetching pods of a specific deployment is fetching pods of other deployments as well.

e.g if I have deployments as `xyz`, `xyz-celery`, `xyz-celery-beat`, and for `xyz` deployment I use the expression `pod=~"^{{ dimension.deployment_name }}.*"`, I am getting the pods of all the deployments having prefix `xyz` i.e `xyz`, `xyz-celery`, `xyz-celery-beat`. It is because of the `.*` property of regex.

The correct expression is `pod=~"^{{ dimension.deployment_name }}-[a-zA-Z0-9]*-[a-zA-Z0-9]*"`

Also for deployment expression `deployment=~"^{{ dimension.deployment_name }}.*"` in case of HPA query, we don't need to use regex. It would be better to use expression - `deployment="{{ dimension.deployment_name }}"`